### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![smithery badge](https://smithery.ai/badge/@jorgeraad/mcp4gql)](https://smithery.ai/server/@jorgeraad/mcp4gql)
 
+<a href="https://glama.ai/mcp/servers/@jorgeraad/mcp4gql">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jorgeraad/mcp4gql/badge" alt="mcp4gql MCP server" />
+</a>
+
 ![mcp4gql](./assets/mcp4gql.png)
 
 This project is a Node.js/TypeScript server that implements the Model Context Protocol (MCP). It acts as a bridge, allowing MCP clients (like Cursor) to interact with a target GraphQL API.


### PR DESCRIPTION
This PR adds a badge for the [mcp4gql](https://glama.ai/mcp/servers/@jorgeraad/mcp4gql) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jorgeraad/mcp4gql">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jorgeraad/mcp4gql/badge" alt="mcp4gql MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.